### PR TITLE
robots.txt added and sitemap fix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ googleAnalytics: G-YMDYGPZL6S
 # Theme i18n support
 # Available values: ar, bn, ca, de, el, en, es, fr, hu, id, it, ja, ko, nl, pt-br, th, uk, zh-cn, zh-hk, zh-tw
 DefaultContentLanguage: en
-
+enableRobotsTXT: false
 # Set hasCJKLanguage to true if DefaultContentLanguage is in [zh-cn ja ko]
 # This will make .Summary and .WordCount behave correctly for CJK languages.
 hasCJKLanguage: true
@@ -239,3 +239,7 @@ markup:
   #imports:
    # - path: github.com/CaiJimmy/hugo-theme-stack/v3
     #  disable: false
+sitemap:
+  changefreq: monthly
+  filename: sitemap.xml
+  priority: 0.5

--- a/public/404.html
+++ b/public/404.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/archives/index.html
+++ b/public/archives/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/cloudflare/index.html
+++ b/public/categories/cloudflare/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/ghost/index.html
+++ b/public/categories/ghost/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/guide/index.html
+++ b/public/categories/guide/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/linux/index.html
+++ b/public/categories/linux/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/obs/index.html
+++ b/public/categories/obs/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/page/2/index.html
+++ b/public/categories/page/2/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/sefl-hosting/index.html
+++ b/public/categories/sefl-hosting/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/streaming/index.html
+++ b/public/categories/streaming/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/syntax/index.html
+++ b/public/categories/syntax/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/test/index.html
+++ b/public/categories/test/index.html
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/categories/themes/index.html
+++ b/public/categories/themes/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/en/sitemap.xml
+++ b/public/en/sitemap.xml
@@ -4,6 +4,8 @@
   <url>
     <loc>https://aerland.xyz/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -17,6 +19,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -30,6 +34,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/cloudflare/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -43,6 +49,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/cms/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -56,6 +64,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/ghost/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -69,6 +79,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/guide/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -82,6 +94,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/guide/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -95,6 +109,8 @@
   </url><url>
     <loc>https://aerland.xyz/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -108,6 +124,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/linux/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -121,6 +139,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/linux/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -134,6 +154,8 @@
   </url><url>
     <loc>https://aerland.xyz/post/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -147,6 +169,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/sefl-hosting/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -160,6 +184,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/self-hosted/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -173,6 +199,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -186,6 +214,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/css/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -199,6 +229,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/html/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -212,6 +244,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/markdown/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -225,6 +259,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/obs/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -238,6 +274,8 @@
   </url><url>
     <loc>https://aerland.xyz/p/obs-split-audio-guide/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -251,6 +289,8 @@
   </url><url>
     <loc>https://aerland.xyz/categories/streaming/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -264,6 +304,8 @@
   </url><url>
     <loc>https://aerland.xyz/tags/themes/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -277,18 +319,28 @@
   </url><url>
     <loc>https://aerland.xyz/p/markdown-syntax-guide/</loc>
     <lastmod>2022-03-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://aerland.xyz/categories/syntax/</loc>
     <lastmod>2022-03-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://aerland.xyz/categories/test/</loc>
     <lastmod>2022-03-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://aerland.xyz/categories/themes/</loc>
     <lastmod>2022-03-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://aerland.xyz/archives/</loc>
     <lastmod>2019-05-28T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -302,6 +354,8 @@
   </url><url>
     <loc>https://aerland.xyz/page/</loc>
     <lastmod>2020-10-09T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -315,6 +369,8 @@
   </url><url>
     <loc>https://aerland.xyz/about/</loc>
     <lastmod>2020-10-09T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -327,6 +383,8 @@
                 />
   </url><url>
     <loc>https://aerland.xyz/links/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"
@@ -339,6 +397,8 @@
                 />
   </url><url>
     <loc>https://aerland.xyz/search/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="ko"

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us" dir="ltr">
     <head>
-	<meta name="generator" content="Hugo 0.100.2" /><meta charset='utf-8'>
+	<meta name="generator" content="Hugo 0.101.0" /><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'><meta name='description' content='Just dumping everything I learn.'><title>Lonus</title>
 
 <link rel='canonical' href='https://aerland.xyz/'>
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/404.html
+++ b/public/ko/404.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/about/index.html
+++ b/public/ko/about/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/archives/index.html
+++ b/public/ko/archives/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/cloudflare/index.html
+++ b/public/ko/categories/cloudflare/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/ghost/index.html
+++ b/public/ko/categories/ghost/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/guide/index.html
+++ b/public/ko/categories/guide/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/index.html
+++ b/public/ko/categories/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/linux/index.html
+++ b/public/ko/categories/linux/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/obs/index.html
+++ b/public/ko/categories/obs/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/page/2/index.html
+++ b/public/ko/categories/page/2/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/sefl-hosting/index.html
+++ b/public/ko/categories/sefl-hosting/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/categories/streaming/index.html
+++ b/public/ko/categories/streaming/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/index.html
+++ b/public/ko/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us" dir="ltr">
     <head>
-	<meta name="generator" content="Hugo 0.100.2" /><meta charset='utf-8'>
+	<meta name="generator" content="Hugo 0.101.0" /><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'><meta name='description' content='Just dumping everything I learn.'><title>로누스</title>
 
 <link rel='canonical' href='https://aerland.xyz/ko/'>
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/links/index.html
+++ b/public/ko/links/index.html
@@ -33,7 +33,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
+++ b/public/ko/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="guide, self-hosted, linux, cms" />
 
 

--- a/public/ko/p/obs-split-audio-guide/index.html
+++ b/public/ko/p/obs-split-audio-guide/index.html
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="markdown, css, html, themes" />
 
 

--- a/public/ko/page/index.html
+++ b/public/ko/page/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/post/index.html
+++ b/public/ko/post/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/search/index.html
+++ b/public/ko/search/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/sitemap.xml
+++ b/public/ko/sitemap.xml
@@ -4,6 +4,8 @@
   <url>
     <loc>https://aerland.xyz/ko/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -17,6 +19,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -30,6 +34,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/cloudflare/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -43,6 +49,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/cms/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -56,6 +64,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/ghost/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -69,6 +79,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/guide/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -82,6 +94,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/guide/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -95,6 +109,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -108,6 +124,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/linux/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -121,6 +139,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/linux/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -134,6 +154,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/post/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -147,6 +169,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/sefl-hosting/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -160,6 +184,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/self-hosted/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -173,6 +199,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/</loc>
     <lastmod>2022-06-15T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -186,6 +214,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/css/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -199,6 +229,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/html/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -212,6 +244,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/markdown/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -225,6 +259,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/obs/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -238,6 +274,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/p/obs-split-audio-guide/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -251,6 +289,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/categories/streaming/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -264,6 +304,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/tags/themes/</loc>
     <lastmod>2022-06-11T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -277,6 +319,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/archives/</loc>
     <lastmod>2019-05-28T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -290,6 +334,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/page/</loc>
     <lastmod>2020-10-09T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -303,6 +349,8 @@
   </url><url>
     <loc>https://aerland.xyz/ko/about/</loc>
     <lastmod>2020-10-09T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -315,6 +363,8 @@
                 />
   </url><url>
     <loc>https://aerland.xyz/ko/links/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"
@@ -327,6 +377,8 @@
                 />
   </url><url>
     <loc>https://aerland.xyz/ko/search/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"

--- a/public/ko/tags/cms/index.html
+++ b/public/ko/tags/cms/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/css/index.html
+++ b/public/ko/tags/css/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/guide/index.html
+++ b/public/ko/tags/guide/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/html/index.html
+++ b/public/ko/tags/html/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/index.html
+++ b/public/ko/tags/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/linux/index.html
+++ b/public/ko/tags/linux/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/markdown/index.html
+++ b/public/ko/tags/markdown/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/page/2/index.html
+++ b/public/ko/tags/page/2/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/self-hosted/index.html
+++ b/public/ko/tags/self-hosted/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/ko/tags/themes/index.html
+++ b/public/ko/tags/themes/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/links/index.html
+++ b/public/links/index.html
@@ -33,7 +33,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
+++ b/public/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="guide, self-hosted, linux, cms" />
 
 

--- a/public/p/markdown-syntax-guide/index.html
+++ b/public/p/markdown-syntax-guide/index.html
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="markdown, css, html, themes" />
 
 

--- a/public/p/obs-split-audio-guide/index.html
+++ b/public/p/obs-split-audio-guide/index.html
@@ -28,7 +28,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="markdown, css, html, themes" />
 
 

--- a/public/page/index.html
+++ b/public/page/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/post/index.html
+++ b/public/post/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Sitemap: https://aerland.xyz/sitemap.xml
+Disallow: /tags/
+Disallow: /categories/

--- a/public/search/index.html
+++ b/public/search/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/cms/index.html
+++ b/public/tags/cms/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/css/index.html
+++ b/public/tags/css/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/guide/index.html
+++ b/public/tags/guide/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/html/index.html
+++ b/public/tags/html/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/linux/index.html
+++ b/public/tags/linux/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/markdown/index.html
+++ b/public/tags/markdown/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/page/2/index.html
+++ b/public/tags/page/2/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/self-hosted/index.html
+++ b/public/tags/self-hosted/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/public/tags/themes/index.html
+++ b/public/tags/themes/index.html
@@ -27,7 +27,6 @@ if (!doNotTrack) {
 </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7891761786816782"
   crossorigin="anonymous"></script>
-
 <meta name="keywords" content="" />
 
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Sitemap: https://aerland.xyz/sitemap.xml
+Disallow: /tags/
+Disallow: /categories/

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,0 +1,24 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{ if not (or (hasPrefix .RelPermalink "/tags") (hasPrefix .RelPermalink "/categories")) }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
# Description

Hugo/Vercel wasn't creating the proper Robots.txt file so I created it manually and also added  `{{ if not (or (hasPrefix .RelPermalink "/tags") (hasPrefix .RelPermalink "/categories")) }}` to the manual sitemap.xml to avoid conflicts with the rotobx.txt file and to properly disallow `tags` and `categories`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
