### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/themes/stack/layouts/partials/sidebar/left.html
+++ b/themes/stack/layouts/partials/sidebar/left.html
@@ -80,7 +80,7 @@
             {{ with .Site.Home.AllTranslations }}
                 <li id="i18n-switch">  
                     {{ partial "helper/icon" "language" }}
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         {{ range . }}
                             <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
                         {{ end }}
@@ -97,4 +97,19 @@
             {{ end }}
         </div>
     </ol>
+<script>
+    function validateAndRedirect(url) {
+        const allowedProtocols = ['http:', 'https:'];
+        try {
+            const parsedUrl = new URL(url, window.location.origin);
+            if (allowedProtocols.includes(parsedUrl.protocol)) {
+                window.location.href = parsedUrl.href;
+            } else {
+                console.error('Invalid URL protocol:', parsedUrl.protocol);
+            }
+        } catch (e) {
+            console.error('Invalid URL:', url);
+        }
+    }
+</script>
 </aside>


### PR DESCRIPTION
Potential fix for [https://github.com/Aerglonus/personal-blog/security/code-scanning/1](https://github.com/Aerglonus/personal-blog/security/code-scanning/1)

To fix the issue, the `value` attribute of the selected `<option>` element should be validated or sanitized before being used to set `window.location.href`. This ensures that only safe URLs are used for redirection. 

The best approach is to use a whitelist of allowed URLs or validate the URL format using a regular expression. Alternatively, escaping the value to prevent XSS attacks can be considered.

Changes to make:
1. Add a validation function to check the safety of the URL before assigning it to `window.location.href`.
2. Update the `onchange` attribute to call the validation function instead of directly using `this.selectedOptions[0].value`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
