### PR TITLE
Potential fix for code scanning alert no. 86: DOM text reinterpreted as HTML

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "deploy-preview"
   deploy-preview:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/public/404.html
+++ b/public/404.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="changeLanguage(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -321,6 +321,18 @@ if (!doNotTrack) {
                 >
             </script><script type="text/javascript" src="/ts/main.js" defer></script>
 <script>
+    function changeLanguage(selectedValue) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(selectedValue)) {
+            window.location.href = selectedValue;
+        } else {
+            console.error("Invalid URL selected");
+        }
+    }
+
     (function () {
         const customFont = document.createElement('link');
         customFont.href = "https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap";

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -284,13 +284,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectedValue) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/archives/index.html
+++ b/public/archives/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/challenges/index.html
+++ b/public/categories/challenges/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL detected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/cloudflare/index.html
+++ b/public/categories/cloudflare/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/ctfs/index.html
+++ b/public/categories/ctfs/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/ghost/index.html
+++ b/public/categories/ghost/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/guide/index.html
+++ b/public/categories/guide/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectedValue) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/hacking/index.html
+++ b/public/categories/hacking/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/linux/index.html
+++ b/public/categories/linux/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -290,6 +290,19 @@ if (!doNotTrack) {
                         
                     </select>
                 </li>
+                <script>
+                    function validateAndRedirect(selectedValue) {
+                        const allowedUrls = [
+                            "https://lonusu.com/",
+                            "https://lonusu.com/ko/"
+                        ];
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error("Invalid URL selected.");
+                        }
+                    }
+                </script>
             
             
             

--- a/public/categories/page/2/index.html
+++ b/public/categories/page/2/index.html
@@ -282,13 +282,23 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="setSafeHref(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function setSafeHref(value) {
+                            const allowedUrls = ["https://lonusu.com/", "https://lonusu.com/ko/"];
+                            if (allowedUrls.includes(value)) {
+                                window.location.href = value;
+                            } else {
+                                console.error("Invalid URL:", value);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/page/3/index.html
+++ b/public/categories/page/3/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/picoctf/index.html
+++ b/public/categories/picoctf/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected:', selectedValue);
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/categories/sefl-hosting/index.html
+++ b/public/categories/sefl-hosting/index.html
@@ -1,5 +1,18 @@
 <!DOCTYPE html>
 <html lang="en-us" dir="ltr">
+<script>
+    function validateAndRedirect(url) {
+        const allowedUrls = [
+            "https://hugo.lonusu.com/",
+            "https://hugo.lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(url)) {
+            window.location.href = url;
+        } else {
+            console.error("Invalid URL:", url);
+        }
+    }
+</script>
     <head><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'><meta name='description' content='Just dumping everything I learn.'><title>Category: Sefl-hosting - Lonus</title>
 
@@ -270,7 +283,7 @@
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://hugo.lonusu.com/" selected>English</option>
                         

--- a/public/categories/self-hosting/index.html
+++ b/public/categories/self-hosting/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/streaming/index.html
+++ b/public/categories/streaming/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="window.location.href = encodeURIComponent(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/categories/syntax/index.html
+++ b/public/categories/syntax/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectedValue) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/test/index.html
+++ b/public/categories/test/index.html
@@ -283,13 +283,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/categories/themes/index.html
+++ b/public/categories/themes/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/index.html
+++ b/public/index.html
@@ -283,7 +283,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/ko/404.html
+++ b/public/ko/404.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndNavigate(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
@@ -320,6 +320,19 @@ if (!doNotTrack) {
                 
                 >
             </script><script type="text/javascript" src="/ts/main.js" defer></script>
+<script>
+    function validateAndNavigate(selectedValue) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(selectedValue)) {
+            window.location.href = selectedValue;
+        } else {
+            console.error("Invalid URL selected:", selectedValue);
+        }
+    }
+</script>
 <script>
     (function () {
         const customFont = document.createElement('link');

--- a/public/ko/about/index.html
+++ b/public/ko/about/index.html
@@ -284,13 +284,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/archives/index.html
+++ b/public/ko/archives/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL detected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/challenges/index.html
+++ b/public/ko/categories/challenges/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndNavigate(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndNavigate(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/cloudflare/index.html
+++ b/public/ko/categories/cloudflare/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="handleLanguageChange(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function handleLanguageChange(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedUrl = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedUrl)) {
+                                window.location.href = selectedUrl;
+                            } else {
+                                console.error("Invalid URL selected");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/ctfs/index.html
+++ b/public/ko/categories/ctfs/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL: Redirection prevented.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/ghost/index.html
+++ b/public/ko/categories/ghost/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/categories/guide/index.html
+++ b/public/ko/categories/guide/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const selectedValue = this.selectedOptions[0].value;
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/categories/hacking/index.html
+++ b/public/ko/categories/hacking/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/index.html
+++ b/public/ko/categories/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/categories/linux/index.html
+++ b/public/ko/categories/linux/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectedValue) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected:", selectedValue);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/obs/index.html
+++ b/public/ko/categories/obs/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="try { const url = new URL(this.selectedOptions[0].value); window.location.href = url.href; } catch (e) { console.error('Invalid URL:', e); }">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/categories/page/2/index.html
+++ b/public/ko/categories/page/2/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="const url = this.selectedOptions[0].value; if (/^https:\/\/lonusu\.com(\/ko\/)?$/.test(url)) { window.location.href = url; } else { console.error('Invalid URL'); }">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/categories/page/3/index.html
+++ b/public/ko/categories/page/3/index.html
@@ -282,13 +282,24 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = ["https://lonusu.com/", "https://lonusu.com/ko/"];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected:", selectedValue);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/picoctf/index.html
+++ b/public/ko/categories/picoctf/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/categories/sefl-hosting/index.html
+++ b/public/ko/categories/sefl-hosting/index.html
@@ -1,4 +1,17 @@
 <!DOCTYPE html>
+<script>
+    function validateAndRedirect(selectedValue) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(selectedValue)) {
+            window.location.href = selectedValue;
+        } else {
+            console.error("Invalid URL selected.");
+        }
+    }
+</script>
 <html lang="ko" dir="ltr">
     <head><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'><meta name='description' content='Just dumping everything I learn.'><title>Category: Sefl-hosting - 로누스</title>
@@ -282,7 +295,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/categories/streaming/index.html
+++ b/public/ko/categories/streaming/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/index.html
+++ b/public/ko/index.html
@@ -283,13 +283,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="changeLanguage(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function changeLanguage(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedUrl = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedUrl)) {
+                                window.location.href = selectedUrl;
+                            } else {
+                                console.error("Invalid URL selected");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/links/index.html
+++ b/public/ko/links/index.html
@@ -290,7 +290,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
@@ -304,6 +304,24 @@ if (!doNotTrack) {
         </div>
     </ol>
 </aside>
+<script>
+    function validateAndRedirect(url) {
+        try {
+            const allowedUrls = [
+                "https://lonusu.com/",
+                "https://lonusu.com/ko/"
+            ];
+            const parsedUrl = new URL(url);
+            if (allowedUrls.includes(parsedUrl.href)) {
+                window.location.href = parsedUrl.href;
+            } else {
+                console.error("Invalid URL:", url);
+            }
+        } catch (e) {
+            console.error("Error parsing URL:", e);
+        }
+    }
+</script>
 <main class="main full-width">
     <article class="main-article">
     <header class="article-header">

--- a/public/ko/p/extracting-the-binary-data-from-a-photo/index.html
+++ b/public/ko/p/extracting-the-binary-data-from-a-photo/index.html
@@ -285,7 +285,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedUrl = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedUrl)) {
+                            window.location.href = selectedUrl;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
+++ b/public/ko/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
@@ -285,13 +285,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectedValue) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/p/obs-split-audio-guide/index.html
+++ b/public/ko/p/obs-split-audio-guide/index.html
@@ -285,7 +285,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
@@ -299,6 +299,19 @@ if (!doNotTrack) {
         </div>
     </ol>
 </aside>
+<script>
+    function validateAndRedirect(value) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(value)) {
+            window.location.href = value;
+        } else {
+            console.error("Invalid URL:", value);
+        }
+    }
+</script>
 <main class="main full-width">
     <article class="has-image main-article">
     <header class="article-header">

--- a/public/ko/page/index.html
+++ b/public/ko/page/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/post/index.html
+++ b/public/ko/post/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/search/index.html
+++ b/public/ko/search/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
@@ -322,6 +322,18 @@ if (!doNotTrack) {
 
 <script>
     window.searchResultTitleTemplate = "#PAGES_COUNT 페이지 (#TIME_SECONDS 초)"
+
+    function validateAndRedirect(url) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(url)) {
+            window.location.href = url;
+        } else {
+            console.error("Invalid URL:", url);
+        }
+    }
 </script><script type="text/javascript" src="/ts/search.js" defer></script>
 
 <footer class="site-footer">

--- a/public/ko/tags/capture-the-flag/index.html
+++ b/public/ko/tags/capture-the-flag/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="const url = this.selectedOptions[0].value; try { const sanitizedUrl = new URL(url); window.location.href = sanitizedUrl.href; } catch (e) { console.error('Invalid URL:', url); }">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/cms/index.html
+++ b/public/ko/tags/cms/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="const url = this.selectedOptions[0].value; try { const safeUrl = new URL(url); window.location.href = safeUrl.href; } catch (e) { console.error('Invalid URL:', url); }">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/css/index.html
+++ b/public/ko/tags/css/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/ctfs/index.html
+++ b/public/ko/tags/ctfs/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedUrl = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedUrl)) {
+                            window.location.href = selectedUrl;
+                        } else {
+                            console.error('Invalid URL selected:', selectedUrl);
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/guide/index.html
+++ b/public/ko/tags/guide/index.html
@@ -282,7 +282,21 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/hacking/index.html
+++ b/public/ko/tags/hacking/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/tags/html/index.html
+++ b/public/ko/tags/html/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="redirectToLanguage(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function redirectToLanguage(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/tags/index.html
+++ b/public/ko/tags/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="const url = this.selectedOptions[0].value; if (/^https:\/\/lonusu\.com(\/ko)?\/?$/.test(url)) { window.location.href = url; }">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/linux/index.html
+++ b/public/ko/tags/linux/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
@@ -290,6 +290,19 @@ if (!doNotTrack) {
                         
                     </select>
                 </li>
+                <script>
+                    function validateAndRedirect(url) {
+                        const allowedUrls = [
+                            "https://lonusu.com/",
+                            "https://lonusu.com/ko/"
+                        ];
+                        if (allowedUrls.includes(url)) {
+                            window.location.href = url;
+                        } else {
+                            console.error("Invalid URL:", url);
+                        }
+                    }
+                </script>
             
             
             

--- a/public/ko/tags/markdown/index.html
+++ b/public/ko/tags/markdown/index.html
@@ -282,7 +282,14 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        try {
+                            const url = new URL(this.selectedOptions[0].value);
+                            window.location.href = url.href;
+                        } catch (e) {
+                            console.error('Invalid URL selected:', e);
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/page/2/index.html
+++ b/public/ko/tags/page/2/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="changeLanguage(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function changeLanguage(url) {
+                            const validUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (validUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/tags/page/3/index.html
+++ b/public/ko/tags/page/3/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/tags/self-hosted/index.html
+++ b/public/ko/tags/self-hosted/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="const url = this.selectedOptions[0].value; if (url.startsWith('https://lonusu.com/')) { window.location.href = encodeURIComponent(url); }">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/ko/tags/themes/index.html
+++ b/public/ko/tags/themes/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="changeLanguage(this)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         
                             <option value="https://lonusu.com/ko/" selected>한국어</option>
                         
                     </select>
+                    <script>
+                        function changeLanguage(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/ko/tags/write-up/index.html
+++ b/public/ko/tags/write-up/index.html
@@ -1,5 +1,18 @@
 <!DOCTYPE html>
 <html lang="ko" dir="ltr">
+<script>
+    function validateAndRedirect(url) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(url)) {
+            window.location.href = url;
+        } else {
+            console.error("Invalid URL:", url);
+        }
+    }
+</script>
     <head><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'><meta name='description' content='Just dumping everything I learn.'><title>Tag: write-up - 로누스</title>
 
@@ -282,7 +295,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" >English</option>
                         

--- a/public/links/index.html
+++ b/public/links/index.html
@@ -290,13 +290,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/p/extracting-the-binary-data-from-a-photo/index.html
+++ b/public/p/extracting-the-binary-data-from-a-photo/index.html
@@ -285,13 +285,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
+++ b/public/p/how-to-install-host-ghost-with-cloudflare-argo-tunnel/index.html
@@ -285,13 +285,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="changeLanguage(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function changeLanguage(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/p/markdown-syntax-guide/index.html
+++ b/public/p/markdown-syntax-guide/index.html
@@ -285,13 +285,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/p/obs-split-audio-guide/index.html
+++ b/public/p/obs-split-audio-guide/index.html
@@ -285,7 +285,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -299,6 +299,19 @@ if (!doNotTrack) {
         </div>
     </ol>
 </aside>
+<script>
+    function validateAndRedirect(selectedValue) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(selectedValue)) {
+            window.location.href = selectedValue;
+        } else {
+            console.error("Invalid URL selected");
+        }
+    }
+</script>
 <main class="main full-width">
     <article class="has-image main-article">
     <header class="article-header">

--- a/public/page/index.html
+++ b/public/page/index.html
@@ -1,4 +1,17 @@
 <!DOCTYPE html>
+<script>
+    function setSafeHref(value) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(value)) {
+            window.location.href = value;
+        } else {
+            console.error("Invalid URL:", value);
+        }
+    }
+</script>
 <html lang="en" dir="ltr">
     <head><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'><meta name='description' content='Just dumping everything I learn.'><title>Pages</title>
@@ -282,7 +295,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="setSafeHref(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/post/index.html
+++ b/public/post/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -296,6 +296,19 @@ if (!doNotTrack) {
         </div>
     </ol>
 </aside>
+<script>
+    function validateAndRedirect(url) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        if (allowedUrls.includes(url)) {
+            window.location.href = url;
+        } else {
+            console.error("Invalid URL detected:", url);
+        }
+    }
+</script>
 <main class="main full-width">
     <header>
         <h3 class="section-title">

--- a/public/search/index.html
+++ b/public/search/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="handleLanguageChange(this)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -353,6 +353,19 @@ if (!doNotTrack) {
 
         document.head.appendChild(customFont);
     }());
+
+    function handleLanguageChange(selectElement) {
+        const allowedUrls = [
+            "https://lonusu.com/",
+            "https://lonusu.com/ko/"
+        ];
+        const selectedValue = selectElement.selectedOptions[0].value;
+        if (allowedUrls.includes(selectedValue)) {
+            window.location.href = selectedValue;
+        } else {
+            console.error("Invalid URL selected:", selectedValue);
+        }
+    }
 </script>
 
     </body>

--- a/public/tags/capture-the-flag/index.html
+++ b/public/tags/capture-the-flag/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedUrl = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedUrl)) {
+                            window.location.href = selectedUrl;
+                        } else {
+                            console.error('Invalid URL selected');
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/tags/cms/index.html
+++ b/public/tags/cms/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected:", selectedValue);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/css/index.html
+++ b/public/tags/css/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -290,6 +290,19 @@ if (!doNotTrack) {
                         
                     </select>
                 </li>
+                <script>
+                    function validateAndRedirect(selectedValue) {
+                        const allowedUrls = [
+                            "https://lonusu.com/",
+                            "https://lonusu.com/ko/"
+                        ];
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error("Invalid URL selected:", selectedValue);
+                        }
+                    }
+                </script>
             
             
             

--- a/public/tags/ctfs/index.html
+++ b/public/tags/ctfs/index.html
@@ -282,7 +282,15 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="
+                        const allowedUrls = ['https://lonusu.com/', 'https://lonusu.com/ko/'];
+                        const selectedValue = this.selectedOptions[0].value;
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error('Invalid URL selected:', selectedValue);
+                        }
+                    ">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/tags/guide/index.html
+++ b/public/tags/guide/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectedValue) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected:", selectedValue);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/hacking/index.html
+++ b/public/tags/hacking/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/html/index.html
+++ b/public/tags/html/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="handleLanguageChange(this)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -290,6 +290,20 @@ if (!doNotTrack) {
                         
                     </select>
                 </li>
+                <script>
+                    function handleLanguageChange(selectElement) {
+                        const selectedValue = selectElement.selectedOptions[0].value;
+                        const allowedUrls = [
+                            "https://lonusu.com/",
+                            "https://lonusu.com/ko/"
+                        ];
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error("Invalid URL selected");
+                        }
+                    }
+                </script>
             
             
             

--- a/public/tags/linux/index.html
+++ b/public/tags/linux/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL selected:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/markdown/index.html
+++ b/public/tags/markdown/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/page/2/index.html
+++ b/public/tags/page/2/index.html
@@ -282,7 +282,21 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         

--- a/public/tags/page/3/index.html
+++ b/public/tags/page/3/index.html
@@ -282,13 +282,27 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(selectElement) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            const selectedValue = selectElement.selectedOptions[0].value;
+                            if (allowedUrls.includes(selectedValue)) {
+                                window.location.href = selectedValue;
+                            } else {
+                                console.error("Invalid URL selected.");
+                            }
+                        }
+                    </script>
                 </li>
             
             

--- a/public/tags/self-hosted/index.html
+++ b/public/tags/self-hosted/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -290,6 +290,19 @@ if (!doNotTrack) {
                         
                     </select>
                 </li>
+                <script>
+                    function validateAndRedirect(selectedValue) {
+                        const allowedUrls = [
+                            "https://lonusu.com/",
+                            "https://lonusu.com/ko/"
+                        ];
+                        if (allowedUrls.includes(selectedValue)) {
+                            window.location.href = selectedValue;
+                        } else {
+                            console.error("Invalid URL selected:", selectedValue);
+                        }
+                    }
+                </script>
             
             
             

--- a/public/tags/themes/index.html
+++ b/public/tags/themes/index.html
@@ -282,7 +282,7 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
@@ -294,6 +294,19 @@ if (!doNotTrack) {
             
             
         </div>
+        <script>
+            function validateAndRedirect(selectedValue) {
+                const allowedUrls = [
+                    "https://lonusu.com/",
+                    "https://lonusu.com/ko/"
+                ];
+                if (allowedUrls.includes(selectedValue)) {
+                    window.location.href = selectedValue;
+                } else {
+                    console.error("Invalid URL selected:", selectedValue);
+                }
+            }
+        </script>
     </ol>
 </aside>
 <main class="main full-width">

--- a/public/tags/write-up/index.html
+++ b/public/tags/write-up/index.html
@@ -282,13 +282,26 @@ if (!doNotTrack) {
 
 
 
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="validateAndRedirect(this.selectedOptions[0].value)">
                         
                             <option value="https://lonusu.com/" selected>English</option>
                         
                             <option value="https://lonusu.com/ko/" >한국어</option>
                         
                     </select>
+                    <script>
+                        function validateAndRedirect(url) {
+                            const allowedUrls = [
+                                "https://lonusu.com/",
+                                "https://lonusu.com/ko/"
+                            ];
+                            if (allowedUrls.includes(url)) {
+                                window.location.href = url;
+                            } else {
+                                console.error("Invalid URL:", url);
+                            }
+                        }
+                    </script>
                 </li>
             
             


### PR DESCRIPTION
Potential fix for [https://github.com/Aerglonus/personal-blog/security/code-scanning/86](https://github.com/Aerglonus/personal-blog/security/code-scanning/86)

To fix the issue, the `value` attribute of the selected `<option>` should be validated or sanitized before being used to set `window.location.href`. A safer approach is to use a whitelist of allowed URLs or validate the URL format before redirecting. This ensures that only trusted URLs are used.

The fix involves:
1. Adding a validation function to check the `value` before assigning it to `window.location.href`.
2. Ensuring that the validation logic is robust and prevents malicious inputs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
